### PR TITLE
More compact raw source output

### DIFF
--- a/src/__tests__/main_alt.test.ts
+++ b/src/__tests__/main_alt.test.ts
@@ -99,12 +99,7 @@ describe('runtype generation', () => {
     );
     const formatted = await fmt(raw);
     expect(formatted).toMatchInlineSnapshot(`
-      "const personRt = rt
-        .Record({
-          name: rt.String,
-          age: rt.Number,
-        })
-        .asReadonly();
+      "const personRt = rt.Record({ name: rt.String, age: rt.Number }).asReadonly();
 
       export const smokeTest = rt.Record({
         someBoolean: rt.Boolean,
@@ -122,12 +117,8 @@ describe('runtype generation', () => {
         someArray: rt.Array(rt.String).asReadonly(),
         someNamedType: personRt,
         someIntersection: rt.Intersect(
-          rt.Record({
-            member1: rt.String,
-          }),
-          rt.Record({
-            member2: rt.Number,
-          }),
+          rt.Record({ member1: rt.String }),
+          rt.Record({ member2: rt.Number }),
         ),
         someObject: rt.Record({
           name: rt.String,
@@ -175,9 +166,7 @@ describe('runtype generation', () => {
       });
       const formatted = await fmt(raw);
       expect(formatted).toMatchInlineSnapshot(`
-        "const test = rt.Record({
-          name: rt.String,
-        });
+        "const test = rt.Record({ name: rt.String });
         "
       `);
     });
@@ -192,11 +181,7 @@ describe('runtype generation', () => {
       });
       const formatted = await fmt(raw);
       expect(formatted).toMatchInlineSnapshot(`
-        "const test = rt
-          .Record({
-            name: rt.String,
-          })
-          .asReadonly();
+        "const test = rt.Record({ name: rt.String }).asReadonly();
         "
       `);
     });
@@ -211,11 +196,7 @@ describe('runtype generation', () => {
       });
       const formatted = await fmt(raw);
       expect(formatted).toMatchInlineSnapshot(`
-        "const test = rt
-          .Record({
-            name: rt.String,
-          })
-          .asPartial();
+        "const test = rt.Record({ name: rt.String }).asPartial();
         "
       `);
     });
@@ -237,12 +218,7 @@ describe('runtype generation', () => {
       });
       const formatted = await fmt(raw);
       expect(formatted).toMatchInlineSnapshot(`
-        "const test = rt
-          .Record({
-            name: rt.String,
-          })
-          .asPartial()
-          .asReadonly();
+        "const test = rt.Record({ name: rt.String }).asPartial().asReadonly();
         "
       `);
     });
@@ -279,25 +255,10 @@ describe('runtype generation', () => {
       const formatted = await fmt(raw);
       expect(formatted).toMatchInlineSnapshot(`
         "const test = rt.intersect(
-          rt.Record({
-            field_1: rt.String,
-          }),
-          rt
-            .Record({
-              field_2: rt.String,
-            })
-            .asPartial(),
-          rt
-            .Record({
-              field_3: rt.String,
-            })
-            .asReadonly(),
-          rt
-            .Record({
-              field_4: rt.String,
-            })
-            .asPartial()
-            .asReadonly(),
+          rt.Record({ field_1: rt.String }),
+          rt.Record({ field_2: rt.String }).asPartial(),
+          rt.Record({ field_3: rt.String }).asReadonly(),
+          rt.Record({ field_4: rt.String }).asPartial().asReadonly(),
         );
         "
       `);

--- a/src/main_alt.ts
+++ b/src/main_alt.ts
@@ -37,7 +37,7 @@ export function generateRuntypes(...roots: RootType[]): string {
   const writer = makeWriter();
   for (const root of roots) {
     writer.conditionalWrite(Boolean(root.export), 'export ');
-    writer.write(`const ${root.name} = `);
+    writer.write(`const ${root.name}=`);
     writeAnyType(writer, root.type);
     writer.write(';\n\n');
   }
@@ -109,21 +109,21 @@ function writeArrayType(w: CodeWriter, node: ArrayType) {
 }
 
 function writeUnionType(w: CodeWriter, node: UnionType) {
-  w.write('\nrt.Union(');
+  w.write('rt.Union(');
   for (const type of node.types) {
     writeAnyType(w, type);
-    w.write(',\n');
+    w.write(',');
   }
-  w.write('\n) ');
+  w.write(')');
 }
 
 function writeIntersectionType(w: CodeWriter, node: UnionType) {
-  w.write('\nrt.Intersect(');
+  w.write('rt.Intersect(');
   for (const type of node.types) {
     writeAnyType(w, type);
-    w.write(',\n');
+    w.write(',');
   }
-  w.write('\n) ');
+  w.write(')');
 }
 
 /**
@@ -167,19 +167,19 @@ export function groupFieldKinds(
 function writeRecordType(w: CodeWriter, node: RecordType) {
   const fieldKinds = groupFieldKinds(node.fields);
   const hasMultiple = fieldKinds.length > 1;
-  w.conditionalWrite(hasMultiple, '\nrt.intersect(');
+  w.conditionalWrite(hasMultiple, 'rt.intersect(');
   for (const fieldKind of fieldKinds) {
-    w.write('rt.Record({\n');
+    w.write('rt.Record({');
     for (const field of fieldKind.fields) {
       w.write(field.name);
-      w.write(': ');
+      w.write(':');
       writeAnyType(w, field.type);
-      w.write(',\n');
+      w.write(',');
     }
     w.write('})');
     w.conditionalWrite(fieldKind.nullable ?? false, '.asPartial()');
     w.conditionalWrite(fieldKind.readonly ?? false, '.asReadonly()');
-    w.conditionalWrite(hasMultiple, '\n,');
+    w.conditionalWrite(hasMultiple, ',');
   }
   w.conditionalWrite(hasMultiple, '\n)');
 }


### PR DESCRIPTION
No point in emitting whitespace/newlines as long as our output looks really bad regardless.

Makes some of the record representation more compact. People should use prettier to adjust this according to their preferences.