### PR TITLE
Feat: generate type definitions

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -97,7 +97,7 @@ describe('runtype generation', () => {
 
       const personRt = rt.Record({ name: rt.String, age: rt.Number }).asReadonly();
 
-      type personRt = rt.Static<typeof personRt>;
+      type PersonRt = rt.Static<typeof personRt>;
 
       export const smokeTest = rt.Record({
         someBoolean: rt.Boolean,
@@ -130,7 +130,7 @@ describe('runtype generation', () => {
         }),
       });
 
-      export type smokeTest = rt.Static<typeof smokeTest>;
+      export type SmokeTest = rt.Static<typeof smokeTest>;
       "
     `);
   });
@@ -169,7 +169,7 @@ describe('runtype generation', () => {
 
         const test = rt.Record({ name: rt.String });
 
-        type test = rt.Static<typeof test>;
+        type Test = rt.Static<typeof test>;
         "
       `);
     });
@@ -187,7 +187,7 @@ describe('runtype generation', () => {
 
         const test = rt.Record({ name: rt.String }).asReadonly();
 
-        type test = rt.Static<typeof test>;
+        type Test = rt.Static<typeof test>;
         "
       `);
     });
@@ -205,7 +205,7 @@ describe('runtype generation', () => {
 
         const test = rt.Record({ name: rt.String }).asPartial();
 
-        type test = rt.Static<typeof test>;
+        type Test = rt.Static<typeof test>;
         "
       `);
     });
@@ -230,7 +230,7 @@ describe('runtype generation', () => {
 
         const test = rt.Record({ name: rt.String }).asPartial().asReadonly();
 
-        type test = rt.Static<typeof test>;
+        type Test = rt.Static<typeof test>;
         "
       `);
     });
@@ -274,7 +274,7 @@ describe('runtype generation', () => {
           rt.Record({ field_4: rt.String }).asPartial().asReadonly()
         );
 
-        type test = rt.Static<typeof test>;
+        type Test = rt.Static<typeof test>;
         "
       `);
     });
@@ -300,7 +300,7 @@ describe('runtype generation', () => {
         .Record({ id: rt.String, name: rt.String, age: rt.String })
         .asReadonly();
 
-      type person = rt.Static<typeof person>;
+      type Person = rt.Static<typeof person>;
       "
     `);
 
@@ -310,7 +310,7 @@ describe('runtype generation', () => {
 
       const person=rt.Record({id:rt.String,name:rt.String,age:rt.String,}).asReadonly();
 
-      type person=rt.Static<typeof person>;"
+      type Person=rt.Static<typeof person>;"
     `);
   });
 
@@ -354,15 +354,15 @@ describe('runtype generation', () => {
 
       const thing = rt.Record({ tag: rt.String });
 
-      type thing = rt.Static<typeof thing>;
+      type Thing = rt.Static<typeof thing>;
 
       const things = rt.Array(thing);
 
-      type things = rt.Static<typeof things>;
+      type Things = rt.Static<typeof things>;
 
       const name = rt.String;
 
-      type name = rt.Static<typeof name>;
+      type Name = rt.Static<typeof name>;
       "
     `);
   });

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -312,6 +312,43 @@ describe('runtype generation', () => {
     expect(source).not.toMatch(/;/);
   });
 
+  it('output types', () => {
+    const source = generateRuntypes(
+      [
+        {
+          name: 'thing',
+          type: {
+            kind: 'record',
+            fields: [{ name: 'tag', type: { kind: 'string' } }],
+          },
+        },
+        {
+          name: 'things',
+          type: { kind: 'array', type: { kind: 'named', name: 'thing' } },
+        },
+        { name: 'name', type: { kind: 'string' } },
+      ],
+      { includeTypes: true },
+    );
+
+    expect(source).toMatchInlineSnapshot(`
+      "import * as rt from \\"runtypes\\";
+
+      const thing = rt.Record({ tag: rt.String });
+
+      type thing = rt.Static<typeof thing>;
+
+      const things = rt.Array(thing);
+
+      type things = rt.Static<typeof things>;
+
+      const name = rt.String;
+
+      type name = rt.Static<typeof name>;
+      "
+    `);
+  });
+
   it.todo('Array');
   it.todo('Boolean');
   it.todo('Brand');

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -97,6 +97,8 @@ describe('runtype generation', () => {
 
       const personRt = rt.Record({ name: rt.String, age: rt.Number }).asReadonly();
 
+      type personRt = rt.Static<typeof personRt>;
+
       export const smokeTest = rt.Record({
         someBoolean: rt.Boolean,
         someNever: rt.Never,
@@ -127,6 +129,8 @@ describe('runtype generation', () => {
           ),
         }),
       });
+
+      export type smokeTest = rt.Static<typeof smokeTest>;
       "
     `);
   });
@@ -164,6 +168,8 @@ describe('runtype generation', () => {
         "import * as rt from \\"runtypes\\";
 
         const test = rt.Record({ name: rt.String });
+
+        type test = rt.Static<typeof test>;
         "
       `);
     });
@@ -180,6 +186,8 @@ describe('runtype generation', () => {
         "import * as rt from \\"runtypes\\";
 
         const test = rt.Record({ name: rt.String }).asReadonly();
+
+        type test = rt.Static<typeof test>;
         "
       `);
     });
@@ -196,6 +204,8 @@ describe('runtype generation', () => {
         "import * as rt from \\"runtypes\\";
 
         const test = rt.Record({ name: rt.String }).asPartial();
+
+        type test = rt.Static<typeof test>;
         "
       `);
     });
@@ -219,6 +229,8 @@ describe('runtype generation', () => {
         "import * as rt from \\"runtypes\\";
 
         const test = rt.Record({ name: rt.String }).asPartial().asReadonly();
+
+        type test = rt.Static<typeof test>;
         "
       `);
     });
@@ -261,6 +273,8 @@ describe('runtype generation', () => {
           rt.Record({ field_3: rt.String }).asReadonly(),
           rt.Record({ field_4: rt.String }).asPartial().asReadonly()
         );
+
+        type test = rt.Static<typeof test>;
         "
       `);
     });
@@ -285,6 +299,8 @@ describe('runtype generation', () => {
       const person = rt
         .Record({ id: rt.String, name: rt.String, age: rt.String })
         .asReadonly();
+
+      type person = rt.Static<typeof person>;
       "
     `);
 
@@ -292,7 +308,9 @@ describe('runtype generation', () => {
     expect(sourceUnformatted).toMatchInlineSnapshot(`
       "import * as rt from \\"runtypes\\";
 
-      const person=rt.Record({id:rt.String,name:rt.String,age:rt.String,}).asReadonly();"
+      const person=rt.Record({id:rt.String,name:rt.String,age:rt.String,}).asReadonly();
+
+      type person=rt.Static<typeof person>;"
     `);
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import { Options as PrettierOptions, format } from 'prettier';
-import * as rt from 'runtypes';
 import {
   AnyType,
   ArrayType,

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,7 @@ const defaultOptions: GenerateOptions = {
   format: true,
   includeImport: true,
   includeTypes: true,
-  formatRuntypeName: (e) => e,
+  formatRuntypeName: (e) => e[0].toLowerCase() + e.slice(1),
   formatTypeName: (e) => e[0].toUpperCase() + e.slice(1),
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,7 +60,7 @@ export interface GenerateOptions {
 const defaultOptions: GenerateOptions = {
   format: true,
   includeImport: true,
-  includeTypes: false,
+  includeTypes: true,
 };
 
 export function generateRuntypes(

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,16 +57,16 @@ export interface GenerateOptions {
   formatOptions?: PrettierOptions;
   includeImport?: boolean;
   includeTypes?: boolean;
-  getRuntypeName?: NameFunction;
-  getTypeName?: NameFunction;
+  formatRuntypeName?: NameFunction;
+  formatTypeName?: NameFunction;
 }
 
 const defaultOptions: GenerateOptions = {
   format: true,
   includeImport: true,
   includeTypes: true,
-  getRuntypeName: (e) => e,
-  getTypeName: (e) => e[0].toUpperCase() + e.slice(1),
+  formatRuntypeName: (e) => e,
+  formatTypeName: (e) => e[0].toUpperCase() + e.slice(1),
 };
 
 export function generateRuntypes(
@@ -94,9 +94,9 @@ function writeRootType(
   w: CodeWriter,
   node: RootType,
 ) {
-  const { includeTypes, getRuntypeName, getTypeName } = options;
-  const runtypeName = getRuntypeName(node.name);
-  const typeName = getTypeName(node.name);
+  const { formatRuntypeName, formatTypeName, includeTypes } = options;
+  const runtypeName = formatRuntypeName(node.name);
+  const typeName = formatTypeName(node.name);
   w.conditionalWrite(Boolean(node.export), 'export ');
   w.write(`const ${runtypeName}=`);
   writeAnyType(w, node.type);

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,17 +50,23 @@ function makeWriter(): CodeWriter {
   };
 }
 
+type NameFunction = (originalName: string) => string;
+
 export interface GenerateOptions {
   format?: boolean;
   formatOptions?: PrettierOptions;
   includeImport?: boolean;
   includeTypes?: boolean;
+  getRuntypeName?: NameFunction;
+  getTypeName?: NameFunction;
 }
 
 const defaultOptions: GenerateOptions = {
   format: true,
   includeImport: true,
   includeTypes: true,
+  getRuntypeName: (e) => e,
+  getTypeName: (e) => e[0].toUpperCase() + e.slice(1),
 };
 
 export function generateRuntypes(
@@ -88,16 +94,18 @@ function writeRootType(
   w: CodeWriter,
   node: RootType,
 ) {
-  const { includeTypes } = options;
+  const { includeTypes, getRuntypeName, getTypeName } = options;
+  const runtypeName = getRuntypeName(node.name);
+  const typeName = getTypeName(node.name);
   w.conditionalWrite(Boolean(node.export), 'export ');
-  w.write(`const ${node.name}=`);
+  w.write(`const ${runtypeName}=`);
   writeAnyType(w, node.type);
   w.write(';\n\n');
 
   w.conditionalWrite(Boolean(node.export) && includeTypes, 'export ');
   w.conditionalWrite(
     includeTypes,
-    `type ${node.name}=rt.Static<typeof ${node.name}>;`,
+    `type ${typeName}=rt.Static<typeof ${runtypeName}>;`,
   );
   w.write('\n\n');
 }


### PR DESCRIPTION
Adds support for type definitions as well as runtypes.

Fixes #28

This is a work in progress. It currently generates types and runtypes with the same names. This is allowed I think, but probably not what most people want.

More discussion on #28 