### PR TITLE
Fix: infinite loop on empty record

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -88,6 +88,13 @@ describe('runtype generation', () => {
                 ],
               },
             },
+            {
+              name: 'emptyObject',
+              type: {
+                kind: 'record',
+                fields: [],
+              },
+            },
           ],
         },
       },
@@ -126,6 +133,7 @@ describe('runtype generation', () => {
             rt.Literal(\\"last\\")
           ),
         }),
+        emptyObject: rt.Record({}),
       });
       "
     `);

--- a/src/main.ts
+++ b/src/main.ts
@@ -208,6 +208,11 @@ export function groupFieldKinds(
 }
 
 function writeRecordType(w: CodeWriter, node: RecordType) {
+  if (node.fields.length === 0) {
+    w.write('rt.Record({})');
+    return;
+  }
+
   const fieldKinds = groupFieldKinds(node.fields);
   const hasMultiple = fieldKinds.length > 1;
   w.conditionalWrite(hasMultiple, 'rt.Intersect(');


### PR DESCRIPTION
Fixes a bug that caused the generator to go into an infinite loop when trying to generate empty record runtype.

Fixes #33, more details there.

I think the problem was caused by `writeRecordType` not writing anything at all if the record had no fields, since `groupFieldKinds` will correctly return and empty array if you pass it an empty array.