### PR TITLE
test: improve coverage + remove redundnant null-coalescing operators

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -277,8 +277,8 @@ function writeRecordType(
       w.write(',');
     }
     w.write('})');
-    w.conditionalWrite(fieldKind.nullable ?? false, '.asPartial()');
-    w.conditionalWrite(fieldKind.readonly ?? false, '.asReadonly()');
+    w.conditionalWrite(fieldKind.nullable, '.asPartial()');
+    w.conditionalWrite(fieldKind.readonly, '.asReadonly()');
     w.conditionalWrite(hasMultiple, ',');
   }
   w.conditionalWrite(hasMultiple, '\n)');


### PR DESCRIPTION
Decided to take care of `it.todo`s in the test file.

## Changes
- added test cases for most of the `it.todo`s in the test file
- deleted `it.todo`s for `Brand`, `Constraint`, and `Tuple` since they're not supported by the lib yet and may be misleading
- removed redundant null coalescing operators (`??`) from the code to get 100% branch coverage :)