### PR TITLE
Add tsconfig for tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   testPathIgnorePatterns: ['.*/dist/.*', '.*dist.*'],
   globals: {
     'ts-jest': {
-      tsconfig: 'tsconfig.json',
+      tsconfig: 'tsconfig.jest.json',
     },
   },
 };

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": true
+  }
+}


### PR DESCRIPTION
The next major version of jest will not have source maps unless the `sourceMap` config option
in tsconfig is true.

I added a custom jest version of the tsconfig that sets this.

Alternatively, we could just enable sourcemaps in the main tsconfig. Any reason we don't?﻿
