### PR TITLE
chore!: Update target to ES2019

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "url": "git+https://github.com/cobraz/generate-runtypes.git"
   },
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=12"
+  },
   "scripts": {
     "dev": "tsnd --respawn src/main.ts",
     "lint": "eslint . --ext .ts,.tsx",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "importHelpers": true,
     "removeComments": true,
     "noLib": false,
-    "target": "es6",
+    "target": "ES2019",
     "sourceMap": false,
     "outDir": "./dist",
     "rootDir": "./src"


### PR DESCRIPTION
The recommended target for node 12 is ES2019. Seems reasonable to have node 12 as the minimum?

The reason I want this is so I can use flatmap in some upcomming code.

If we really need to target older ES versions, I can add a flatten function in that PR instead

