### PR TITLE
refactor: Move non-public utilities to their own file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,5 +7,7 @@ generate-runtypes
 ### Modules
 
 - [\_\_tests\_\_/main.test](modules/__tests___main_test.md)
+- [\_\_tests\_\_/util.test](modules/__tests___util_test.md)
 - [main](modules/main.md)
 - [types](modules/types.md)
+- [util](modules/util.md)

--- a/docs/interfaces/main.generateoptions.md
+++ b/docs/interfaces/main.generateoptions.md
@@ -23,7 +23,7 @@
 
 Apply formatting to the output using prettier. Default: true
 
-Defined in: [src/main.ts:57](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/main.ts#L57)
+Defined in: [src/main.ts:58](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/main.ts#L58)
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 Options to use for prettier formatting. Default: undefined
 
-Defined in: [src/main.ts:60](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/main.ts#L60)
+Defined in: [src/main.ts:61](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/main.ts#L61)
 
 ___
 
@@ -45,7 +45,7 @@ Function used to format the names of generated runtypes.
 The function is passed in a name and must return a string that will be
 used in place of that name.
 
-Defined in: [src/main.ts:94](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/main.ts#L94)
+Defined in: [src/main.ts:95](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/main.ts#L95)
 
 ___
 
@@ -57,7 +57,7 @@ Function used to format the names of generated type.
 The function is passed in a name and must return a string that will be
 used in place of that name.
 
-Defined in: [src/main.ts:101](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/main.ts#L101)
+Defined in: [src/main.ts:102](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/main.ts#L102)
 
 ___
 
@@ -70,7 +70,7 @@ When turned on, `import * as rt from "runtypes";` will be added at the
 top of the generated code.
 Default: true
 
-Defined in: [src/main.ts:68](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/main.ts#L68)
+Defined in: [src/main.ts:69](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/main.ts#L69)
 
 ___
 
@@ -94,4 +94,4 @@ const myRuntype = rt.Record({ name: rt.String });
 type MyRuntype = rt.Static<typeof myRuntype>;
 ```
 
-Defined in: [src/main.ts:87](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/main.ts#L87)
+Defined in: [src/main.ts:88](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/main.ts#L88)

--- a/docs/modules/__tests___util_test.md
+++ b/docs/modules/__tests___util_test.md
@@ -1,0 +1,3 @@
+[generate-runtypes](../README.md) / __tests__/util.test
+
+# Module: \_\_tests\_\_/util.test

--- a/docs/modules/main.md
+++ b/docs/modules/main.md
@@ -25,7 +25,6 @@
 ### Functions
 
 - [generateRuntypes](main.md#generateruntypes)
-- [groupFieldKinds](main.md#groupfieldkinds)
 
 ## References
 
@@ -102,24 +101,4 @@ Re-exports: [rootTypeRt](types.md#roottypert)
 
 **Returns:** *string*
 
-Defined in: [src/main.ts:117](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/main.ts#L117)
-
-___
-
-### groupFieldKinds
-
-▸ `Private` **groupFieldKinds**(`fields`: readonly [*RecordField*](types.md#recordfield)[]): { `fields`: [*RecordField*](types.md#recordfield)[] ; `nullable`: *boolean* ; `readonly`: *boolean*  }[]
-
-public for testing
-
-Used to evaluate if `Record` type include `readonly` and/or `nullable`
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `fields` | readonly [*RecordField*](types.md#recordfield)[] |
-
-**Returns:** { `fields`: [*RecordField*](types.md#recordfield)[] ; `nullable`: *boolean* ; `readonly`: *boolean*  }[]
-
-Defined in: [src/main.ts:295](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/main.ts#L295)
+Defined in: [src/main.ts:118](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/main.ts#L118)

--- a/docs/modules/types.md
+++ b/docs/modules/types.md
@@ -28,7 +28,7 @@
 
 Ƭ **AnyType**: *rt.Static*<*typeof* anyTypeRt\>
 
-Defined in: [src/types.ts:162](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/types.ts#L162)
+Defined in: [src/types.ts:162](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/types.ts#L162)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 | `readonly?` | *boolean* |
 | `type` | [*AnyType*](types.md#anytype) |
 
-Defined in: [src/types.ts:78](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/types.ts#L78)
+Defined in: [src/types.ts:78](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/types.ts#L78)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 | `kind` | ``"dictionary"`` |
 | `valueType` | [*AnyType*](types.md#anytype) |
 
-Defined in: [src/types.ts:95](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/types.ts#L95)
+Defined in: [src/types.ts:95](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/types.ts#L95)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 | `kind` | ``"intersect"`` |
 | `types` | [*AnyType*](types.md#anytype)[] |
 
-Defined in: [src/types.ts:130](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/types.ts#L130)
+Defined in: [src/types.ts:130](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/types.ts#L130)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 Ƭ **LiteralType**: *rt.Static*<*typeof* literalTypeRt\>
 
-Defined in: [src/types.ts:32](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/types.ts#L32)
+Defined in: [src/types.ts:32](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/types.ts#L32)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 Ƭ **NamedType**: *rt.Static*<*typeof* namedTypeRt\>
 
-Defined in: [src/types.ts:46](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/types.ts#L46)
+Defined in: [src/types.ts:46](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/types.ts#L46)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 | `readonly?` | *boolean* |
 | `type` | [*AnyType*](types.md#anytype) |
 
-Defined in: [src/types.ts:48](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/types.ts#L48)
+Defined in: [src/types.ts:48](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/types.ts#L48)
 
 ___
 
@@ -123,7 +123,7 @@ ___
 | `fields` | [*RecordField*](types.md#recordfield)[] |
 | `kind` | ``"record"`` |
 
-Defined in: [src/types.ts:56](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/types.ts#L56)
+Defined in: [src/types.ts:56](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/types.ts#L56)
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 Ƭ **RootType**: *rt.Static*<*typeof* [*rootTypeRt*](types.md#roottypert)\>
 
-Defined in: [src/types.ts:174](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/types.ts#L174)
+Defined in: [src/types.ts:174](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/types.ts#L174)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 Ƭ **SimpleType**: *rt.Static*<*typeof* simpleTypeRt\>
 
-Defined in: [src/types.ts:21](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/types.ts#L21)
+Defined in: [src/types.ts:21](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/types.ts#L21)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 | `kind` | ``"union"`` |
 | `types` | [*AnyType*](types.md#anytype)[] |
 
-Defined in: [src/types.ts:110](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/types.ts#L110)
+Defined in: [src/types.ts:110](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/types.ts#L110)
 
 ## Variables
 
@@ -162,4 +162,4 @@ Defined in: [src/types.ts:110](https://github.com/cobraz/generate-runtypes/blob/
 
 • `Const` **rootTypeRt**: *Intersect*<[*Record*<{ `name`: *String* ; `type`: *Union*<[*Runtype*<[*ArrayType*](types.md#arraytype)\>, *Runtype*<[*DictionaryType*](types.md#dictionarytype)\>, *Runtype*<[*IntersectionType*](types.md#intersectiontype)\>, *Record*<{ `kind`: *Literal*<``"literal"``\> ; `value`: *Union*<[*Boolean*, *Literal*<``null``\>, *Number*, *String*, *Literal*<undefined\>]\>  }, ``false``\>, *Record*<{ `kind`: *Literal*<``"named"``\> ; `name`: *String*  }, ``false``\>, *Runtype*<[*RecordType*](types.md#recordtype)\>, *Record*<{ `kind`: *Union*<[*Literal*<``"boolean"``\>, *Literal*<``"function"``\>, *Literal*<``"never"``\>, *Literal*<``"null"``\>, *Literal*<``"number"``\>, *Literal*<``"string"``\>, *Literal*<``"symbol"``\>, *Literal*<``"undefined"``\>, *Literal*<``"unknown"``\>]\>  }, ``false``\>, *Runtype*<[*UnionType*](types.md#uniontype)\>]\>  }, ``false``\>, *InternalRecord*<{ `comment`: *Union*<[*String*, *Arr*<String, ``false``\>]\> ; `export`: *Boolean*  }, ``true``, ``false``\>]\>
 
-Defined in: [src/types.ts:164](https://github.com/cobraz/generate-runtypes/blob/5e188fd/src/types.ts#L164)
+Defined in: [src/types.ts:164](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/types.ts#L164)

--- a/docs/modules/util.md
+++ b/docs/modules/util.md
@@ -1,0 +1,29 @@
+[generate-runtypes](../README.md) / util
+
+# Module: util
+
+## Table of contents
+
+### Functions
+
+- [groupFieldKinds](util.md#groupfieldkinds)
+
+## Functions
+
+### groupFieldKinds
+
+▸ `Private` **groupFieldKinds**(`fields`: readonly [*RecordField*](types.md#recordfield)[]): { `fields`: [*RecordField*](types.md#recordfield)[] ; `nullable`: *boolean* ; `readonly`: *boolean*  }[]
+
+public for testing
+
+Used to evaluate if `Record` type include `readonly` and/or `nullable`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `fields` | readonly [*RecordField*](types.md#recordfield)[] |
+
+**Returns:** { `fields`: [*RecordField*](types.md#recordfield)[] ; `nullable`: *boolean* ; `readonly`: *boolean*  }[]
+
+Defined in: [src/util.ts:9](https://github.com/cobraz/generate-runtypes/blob/1c53623/src/util.ts#L9)

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -1,4 +1,4 @@
-import { generateRuntypes, groupFieldKinds } from '../main';
+import { generateRuntypes } from '../main';
 import { RootType } from '../types';
 
 describe('runtype generation', () => {
@@ -148,26 +148,6 @@ describe('runtype generation', () => {
   });
 
   describe('objects', () => {
-    it('groupFieldKinds', () => {
-      const res = groupFieldKinds([
-        { name: 'field_1', type: { kind: 'string' } },
-        { name: 'field_2', type: { kind: 'string' }, nullable: true },
-        { name: 'field_3', type: { kind: 'string' }, readonly: true },
-        {
-          name: 'field_4',
-          type: { kind: 'string' },
-          nullable: true,
-          readonly: true,
-        },
-      ]);
-
-      const [default_, nullable, readonly, both] = res;
-      expect(default_.fields.map((e) => e.name)).toEqual(['field_1']);
-      expect(nullable.fields.map((e) => e.name)).toEqual(['field_2']);
-      expect(readonly.fields.map((e) => e.name)).toEqual(['field_3']);
-      expect(both.fields.map((e) => e.name)).toEqual(['field_4']);
-    });
-
     it('default modifiers', async () => {
       const raw = generateRuntypes({
         name: 'test',

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -1,0 +1,23 @@
+import { groupFieldKinds } from '../util';
+
+describe('groupFieldKinds', () => {
+  it('smoke test', () => {
+    const res = groupFieldKinds([
+      { name: 'field_1', type: { kind: 'string' } },
+      { name: 'field_2', type: { kind: 'string' }, nullable: true },
+      { name: 'field_3', type: { kind: 'string' }, readonly: true },
+      {
+        name: 'field_4',
+        type: { kind: 'string' },
+        nullable: true,
+        readonly: true,
+      },
+    ]);
+
+    const [default_, nullable, readonly, both] = res;
+    expect(default_.fields.map((e) => e.name)).toEqual(['field_1']);
+    expect(nullable.fields.map((e) => e.name)).toEqual(['field_2']);
+    expect(readonly.fields.map((e) => e.name)).toEqual(['field_3']);
+    expect(both.fields.map((e) => e.name)).toEqual(['field_4']);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
   UnionType,
   rootTypeRt,
 } from './types';
+import { groupFieldKinds } from './util';
 
 export type {
   PrettierOptions,
@@ -284,41 +285,6 @@ function writeComment(w: CodeWriter, comment: string | string[]) {
     }
     w.write(`*/\n`);
   }
-}
-
-/**
- * public for testing
- *
- * Used to evaluate if `Record` type include `readonly` and/or `nullable`
- * @private
- */
-export function groupFieldKinds(fields: readonly RecordField[]): {
-  readonly: boolean;
-  nullable: boolean;
-  fields: RecordField[];
-}[] {
-  return [
-    {
-      readonly: false,
-      nullable: false,
-      fields: fields.filter((e) => !e.readonly && !e.nullable),
-    },
-    {
-      readonly: false,
-      nullable: true,
-      fields: fields.filter((e) => !e.readonly && e.nullable),
-    },
-    {
-      readonly: true,
-      nullable: false,
-      fields: fields.filter((e) => e.readonly && !e.nullable),
-    },
-    {
-      readonly: true,
-      nullable: true,
-      fields: fields.filter((e) => e.readonly && e.nullable),
-    },
-  ].filter((e) => e.fields.length > 0);
 }
 
 function writeRecordType(

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,36 @@
+import { RecordField } from './types';
+
+/**
+ * public for testing
+ *
+ * Used to evaluate if `Record` type include `readonly` and/or `nullable`
+ * @private
+ */
+export function groupFieldKinds(fields: readonly RecordField[]): {
+  readonly: boolean;
+  nullable: boolean;
+  fields: RecordField[];
+}[] {
+  return [
+    {
+      readonly: false,
+      nullable: false,
+      fields: fields.filter((e) => !e.readonly && !e.nullable),
+    },
+    {
+      readonly: false,
+      nullable: true,
+      fields: fields.filter((e) => !e.readonly && e.nullable),
+    },
+    {
+      readonly: true,
+      nullable: false,
+      fields: fields.filter((e) => e.readonly && !e.nullable),
+    },
+    {
+      readonly: true,
+      nullable: true,
+      fields: fields.filter((e) => e.readonly && e.nullable),
+    },
+  ].filter((e) => e.fields.length > 0);
+}


### PR DESCRIPTION
Two reasons why I want this:

1. The function moved from main has to be exported for tests. But when it's in main it's also visible to anyone using the package. It should be a private function.
2. In upcoming changes I'm doing I need more utility functions. Makes sense to not grow main that much bigger.
