### PR TITLE
feat: Add flag to detect unknown named types

### DIFF
--- a/docs/interfaces/main.generateoptions.md
+++ b/docs/interfaces/main.generateoptions.md
@@ -15,6 +15,7 @@
 - [includeImport](main.generateoptions.md#includeimport)
 - [includeTypes](main.generateoptions.md#includetypes)
 - [rejectCyclicDependencies](main.generateoptions.md#rejectcyclicdependencies)
+- [rejectUnknownNamedTypes](main.generateoptions.md#rejectunknownnamedtypes)
 
 ## Properties
 
@@ -24,7 +25,7 @@
 
 Apply formatting to the output using prettier. Default: true
 
-Defined in: [src/main.ts:59](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/main.ts#L59)
+Defined in: [src/main.ts:58](https://github.com/cobraz/generate-runtypes/blob/7317811/src/main.ts#L58)
 
 ___
 
@@ -34,7 +35,7 @@ ___
 
 Options to use for prettier formatting. Default: undefined
 
-Defined in: [src/main.ts:62](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/main.ts#L62)
+Defined in: [src/main.ts:61](https://github.com/cobraz/generate-runtypes/blob/7317811/src/main.ts#L61)
 
 ___
 
@@ -46,7 +47,7 @@ Function used to format the names of generated runtypes.
 The function is passed in a name and must return a string that will be
 used in place of that name.
 
-Defined in: [src/main.ts:96](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/main.ts#L96)
+Defined in: [src/main.ts:95](https://github.com/cobraz/generate-runtypes/blob/7317811/src/main.ts#L95)
 
 ___
 
@@ -58,7 +59,7 @@ Function used to format the names of generated type.
 The function is passed in a name and must return a string that will be
 used in place of that name.
 
-Defined in: [src/main.ts:103](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/main.ts#L103)
+Defined in: [src/main.ts:102](https://github.com/cobraz/generate-runtypes/blob/7317811/src/main.ts#L102)
 
 ___
 
@@ -71,7 +72,7 @@ When turned on, `import * as rt from "runtypes";` will be added at the
 top of the generated code.
 Default: true
 
-Defined in: [src/main.ts:70](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/main.ts#L70)
+Defined in: [src/main.ts:69](https://github.com/cobraz/generate-runtypes/blob/7317811/src/main.ts#L69)
 
 ___
 
@@ -95,7 +96,7 @@ const myRuntype = rt.Record({ name: rt.String });
 type MyRuntype = rt.Static<typeof myRuntype>;
 ```
 
-Defined in: [src/main.ts:89](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/main.ts#L89)
+Defined in: [src/main.ts:88](https://github.com/cobraz/generate-runtypes/blob/7317811/src/main.ts#L88)
 
 ___
 
@@ -107,4 +108,18 @@ Whether to throw when encountering root types with cyclic dependencies,
 or emit possibly broken code for them.
 Default: false
 
-Defined in: [src/main.ts:110](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/main.ts#L110)
+Defined in: [src/main.ts:109](https://github.com/cobraz/generate-runtypes/blob/7317811/src/main.ts#L109)
+
+___
+
+### rejectUnknownNamedTypes
+
+• `Optional` **rejectUnknownNamedTypes**: *boolean*
+
+Whether to throw when encountering a named type that's not one of the, root
+types. Useful for caching typos when generating code. Must be disabled when
+using named types that are not part of the ones being generated.
+
+Default: false
+
+Defined in: [src/main.ts:118](https://github.com/cobraz/generate-runtypes/blob/7317811/src/main.ts#L118)

--- a/docs/modules/main.md
+++ b/docs/modules/main.md
@@ -101,4 +101,4 @@ Re-exports: [rootTypeRt](types.md#roottypert)
 
 **Returns:** *string*
 
-Defined in: [src/main.ts:127](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/main.ts#L127)
+Defined in: [src/main.ts:136](https://github.com/cobraz/generate-runtypes/blob/7317811/src/main.ts#L136)

--- a/docs/modules/types.md
+++ b/docs/modules/types.md
@@ -28,7 +28,7 @@
 
 Ƭ **AnyType**: *rt.Static*<*typeof* anyTypeRt\>
 
-Defined in: [src/types.ts:162](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/types.ts#L162)
+Defined in: [src/types.ts:162](https://github.com/cobraz/generate-runtypes/blob/7317811/src/types.ts#L162)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 | `readonly?` | *boolean* |
 | `type` | [*AnyType*](types.md#anytype) |
 
-Defined in: [src/types.ts:78](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/types.ts#L78)
+Defined in: [src/types.ts:78](https://github.com/cobraz/generate-runtypes/blob/7317811/src/types.ts#L78)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 | `kind` | ``"dictionary"`` |
 | `valueType` | [*AnyType*](types.md#anytype) |
 
-Defined in: [src/types.ts:95](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/types.ts#L95)
+Defined in: [src/types.ts:95](https://github.com/cobraz/generate-runtypes/blob/7317811/src/types.ts#L95)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 | `kind` | ``"intersect"`` |
 | `types` | [*AnyType*](types.md#anytype)[] |
 
-Defined in: [src/types.ts:130](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/types.ts#L130)
+Defined in: [src/types.ts:130](https://github.com/cobraz/generate-runtypes/blob/7317811/src/types.ts#L130)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 Ƭ **LiteralType**: *rt.Static*<*typeof* literalTypeRt\>
 
-Defined in: [src/types.ts:32](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/types.ts#L32)
+Defined in: [src/types.ts:32](https://github.com/cobraz/generate-runtypes/blob/7317811/src/types.ts#L32)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 Ƭ **NamedType**: *rt.Static*<*typeof* namedTypeRt\>
 
-Defined in: [src/types.ts:46](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/types.ts#L46)
+Defined in: [src/types.ts:46](https://github.com/cobraz/generate-runtypes/blob/7317811/src/types.ts#L46)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 | `readonly?` | *boolean* |
 | `type` | [*AnyType*](types.md#anytype) |
 
-Defined in: [src/types.ts:48](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/types.ts#L48)
+Defined in: [src/types.ts:48](https://github.com/cobraz/generate-runtypes/blob/7317811/src/types.ts#L48)
 
 ___
 
@@ -123,7 +123,7 @@ ___
 | `fields` | [*RecordField*](types.md#recordfield)[] |
 | `kind` | ``"record"`` |
 
-Defined in: [src/types.ts:56](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/types.ts#L56)
+Defined in: [src/types.ts:56](https://github.com/cobraz/generate-runtypes/blob/7317811/src/types.ts#L56)
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 Ƭ **RootType**: *rt.Static*<*typeof* [*rootTypeRt*](types.md#roottypert)\>
 
-Defined in: [src/types.ts:174](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/types.ts#L174)
+Defined in: [src/types.ts:174](https://github.com/cobraz/generate-runtypes/blob/7317811/src/types.ts#L174)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 Ƭ **SimpleType**: *rt.Static*<*typeof* simpleTypeRt\>
 
-Defined in: [src/types.ts:21](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/types.ts#L21)
+Defined in: [src/types.ts:21](https://github.com/cobraz/generate-runtypes/blob/7317811/src/types.ts#L21)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 | `kind` | ``"union"`` |
 | `types` | [*AnyType*](types.md#anytype)[] |
 
-Defined in: [src/types.ts:110](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/types.ts#L110)
+Defined in: [src/types.ts:110](https://github.com/cobraz/generate-runtypes/blob/7317811/src/types.ts#L110)
 
 ## Variables
 
@@ -162,4 +162,4 @@ Defined in: [src/types.ts:110](https://github.com/cobraz/generate-runtypes/blob/
 
 • `Const` **rootTypeRt**: *Intersect*<[*Record*<{ `name`: *String* ; `type`: *Union*<[*Runtype*<[*ArrayType*](types.md#arraytype)\>, *Runtype*<[*DictionaryType*](types.md#dictionarytype)\>, *Runtype*<[*IntersectionType*](types.md#intersectiontype)\>, *Record*<{ `kind`: *Literal*<``"literal"``\> ; `value`: *Union*<[*Boolean*, *Literal*<``null``\>, *Number*, *String*, *Literal*<undefined\>]\>  }, ``false``\>, *Record*<{ `kind`: *Literal*<``"named"``\> ; `name`: *String*  }, ``false``\>, *Runtype*<[*RecordType*](types.md#recordtype)\>, *Record*<{ `kind`: *Union*<[*Literal*<``"boolean"``\>, *Literal*<``"function"``\>, *Literal*<``"never"``\>, *Literal*<``"null"``\>, *Literal*<``"number"``\>, *Literal*<``"string"``\>, *Literal*<``"symbol"``\>, *Literal*<``"undefined"``\>, *Literal*<``"unknown"``\>]\>  }, ``false``\>, *Runtype*<[*UnionType*](types.md#uniontype)\>]\>  }, ``false``\>, *InternalRecord*<{ `comment`: *Union*<[*String*, *Arr*<String, ``false``\>]\> ; `export`: *Boolean*  }, ``true``, ``false``\>]\>
 
-Defined in: [src/types.ts:164](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/types.ts#L164)
+Defined in: [src/types.ts:164](https://github.com/cobraz/generate-runtypes/blob/7317811/src/types.ts#L164)

--- a/docs/modules/util.md
+++ b/docs/modules/util.md
@@ -8,6 +8,7 @@
 
 - [getCyclicDependencies](util.md#getcyclicdependencies)
 - [getNamedTypes](util.md#getnamedtypes)
+- [getUnknownNamedTypes](util.md#getunknownnamedtypes)
 - [groupFieldKinds](util.md#groupfieldkinds)
 
 ## Functions
@@ -32,7 +33,7 @@ types.
 
 **Returns:** [*string*, *string*][]
 
-Defined in: [src/util.ts:123](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/util.ts#L123)
+Defined in: [src/util.ts:123](https://github.com/cobraz/generate-runtypes/blob/7317811/src/util.ts#L123)
 
 ___
 
@@ -52,7 +53,25 @@ public for testing
 
 **Returns:** readonly *string*[]
 
-Defined in: [src/util.ts:72](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/util.ts#L72)
+Defined in: [src/util.ts:72](https://github.com/cobraz/generate-runtypes/blob/7317811/src/util.ts#L72)
+
+___
+
+### getUnknownNamedTypes
+
+▸ `Private` **getUnknownNamedTypes**(`roots`: [*RootType*](types.md#roottype)[]): readonly *string*[]
+
+public for testing
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `roots` | [*RootType*](types.md#roottype)[] |
+
+**Returns:** readonly *string*[]
+
+Defined in: [src/util.ts:154](https://github.com/cobraz/generate-runtypes/blob/7317811/src/util.ts#L154)
 
 ___
 
@@ -72,4 +91,4 @@ Used to evaluate if `Record` type include `readonly` and/or `nullable`
 
 **Returns:** { `fields`: [*RecordField*](types.md#recordfield)[] ; `nullable`: *boolean* ; `readonly`: *boolean*  }[]
 
-Defined in: [src/util.ts:10](https://github.com/cobraz/generate-runtypes/blob/0a259e5/src/util.ts#L10)
+Defined in: [src/util.ts:10](https://github.com/cobraz/generate-runtypes/blob/7317811/src/util.ts#L10)

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -1,6 +1,10 @@
 import { RootType } from '../main';
-import { getCyclicDependencies, getNamedTypes } from '../util';
-import { groupFieldKinds } from '../util';
+import {
+  getCyclicDependencies,
+  getNamedTypes,
+  getUnknownNamedTypes,
+  groupFieldKinds,
+} from '../util';
 
 describe('groupFieldKinds', () => {
   it('smoke test', () => {
@@ -198,4 +202,39 @@ describe('getNamedTypes', () => {
   });
 
   it.todo('unions, arrays etc');
+});
+
+describe('getUknownNamedTypes', () => {
+  it('finds unknown types', () => {
+    const roots: RootType[] = [
+      { name: 'internal', type: { kind: 'string' } },
+      {
+        name: 'foo',
+        type: {
+          kind: 'record',
+          fields: [
+            { name: 'first', type: { kind: 'named', name: 'external' } },
+            { name: 'second', type: { kind: 'named', name: 'internal' } },
+          ],
+        },
+      },
+    ];
+    expect(getUnknownNamedTypes(roots)).toEqual(['external']);
+  });
+
+  it('empty result when no unknown', () => {
+    const roots: RootType[] = [
+      { name: 'internal', type: { kind: 'string' } },
+      {
+        name: 'foo',
+        type: {
+          kind: 'record',
+          fields: [
+            { name: 'second', type: { kind: 'named', name: 'internal' } },
+          ],
+        },
+      },
+    ];
+    expect(getUnknownNamedTypes(roots)).toEqual([]);
+  });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,7 @@ import {
   UnionType,
   rootTypeRt,
 } from './types';
-import { getCyclicDependencies } from './util';
-import { groupFieldKinds } from './util';
+import { getCyclicDependencies, groupFieldKinds } from './util';
 
 export type {
   PrettierOptions,
@@ -108,6 +107,15 @@ export interface GenerateOptions {
    * Default: false
    */
   rejectCyclicDependencies?: boolean;
+
+  /**
+   * Whether to throw when encountering a named type that's not one of the, root
+   * types. Useful for caching typos when generating code. Must be disabled when
+   * using named types that are not part of the ones being generated.
+   *
+   * Default: false
+   */
+  rejectUnknownNamedTypes?: boolean;
 }
 
 const defaultOptions: GenerateOptions = {
@@ -117,6 +125,7 @@ const defaultOptions: GenerateOptions = {
   formatRuntypeName: (e) => e[0].toLowerCase() + e.slice(1),
   formatTypeName: (e) => e[0].toUpperCase() + e.slice(1),
   rejectCyclicDependencies: false,
+  rejectUnknownNamedTypes: false,
 };
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -144,3 +144,15 @@ export function getCyclicDependencies(roots: RootType[]): [string, string][] {
 
   return ret;
 }
+
+/**
+ * public for testing
+ * @private
+ * @param roots
+ * @returns
+ */
+export function getUnknownNamedTypes(roots: RootType[]): readonly string[] {
+  const rootNames = roots.map((e) => e.name);
+  const namedTypes = roots.flatMap((e) => getNamedTypes(e.type));
+  return namedTypes.filter((e) => !rootNames.includes(e));
+}


### PR DESCRIPTION
Adds a `rejectUnknownNamedTypes` option. If true, the generator throws if it encounters a named type that's not one of the root types.

The default value is `false`, so this shouldn't break anything.