### PR TITLE
feat: Topological sort of dependencies

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -757,7 +757,16 @@ describe('runtype generation', () => {
       );
 
       expect(source).toMatchInlineSnapshot(`
-        "type person_Type = {
+        "type job_Type = {
+          title: string;
+          people: person_Type[];
+        };
+
+        const job_runtype: rt.Runtype<job_Type> = rt.Lazy(() =>
+          rt.Record({ title: rt.String, people: rt.Array(person_runtype) })
+        );
+
+        type person_Type = {
           name: string;
           parent: person_Type;
           job: job_Type;
@@ -765,15 +774,6 @@ describe('runtype generation', () => {
 
         const person_runtype: rt.Runtype<person_Type> = rt.Lazy(() =>
           rt.Record({ name: rt.String, parent: person_runtype, job: job_runtype })
-        );
-
-        type job_Type = {
-          title: string;
-          people: person_Type[];
-        };
-
-        const job_runtype: rt.Runtype<job_Type> = rt.Lazy(() =>
-          rt.Record({ title: rt.String, people: rt.Array(person_runtype) })
         );
         "
       `);
@@ -841,6 +841,64 @@ describe('runtype generation', () => {
         const person_runtype: rt.Runtype<person_Type> = rt.Lazy(() =>
           rt.Record({ name: rt.String, parent: person_runtype })
         );
+        "
+      `);
+    });
+
+    it('mising lazy and non-lazy', () => {
+      const source = generateRuntypes(
+        [
+          {
+            name: 'job',
+            type: {
+              kind: 'record',
+              fields: [
+                { name: 'title', type: { kind: 'string' } },
+                {
+                  name: 'people',
+                  type: {
+                    kind: 'array',
+                    type: { kind: 'named', name: 'person' },
+                  },
+                },
+              ],
+            },
+          },
+
+          {
+            name: 'person',
+            type: {
+              kind: 'record',
+              fields: [
+                { name: 'name', type: { kind: 'string' } },
+                { name: 'parent', type: { kind: 'named', name: 'person' } },
+              ],
+            },
+          },
+        ],
+        {
+          formatRuntypeName: (e) => `${e}_runtype`,
+          formatTypeName: (e) => `${e}_Type`,
+          includeImport: false,
+        },
+      );
+
+      expect(source).toMatchInlineSnapshot(`
+        "type person_Type = {
+          name: string;
+          parent: person_Type;
+        };
+
+        const person_runtype: rt.Runtype<person_Type> = rt.Lazy(() =>
+          rt.Record({ name: rt.String, parent: person_runtype })
+        );
+
+        const job_runtype = rt.Record({
+          title: rt.String,
+          people: rt.Array(person_runtype),
+        });
+
+        type job_Type = rt.Static<typeof job_runtype>;
         "
       `);
     });

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -472,8 +472,6 @@ describe('anyTypeToTsType', () => {
   });
 
   describe('topoSortRoots', () => {
-    it.todo('test cyclic stuff');
-
     it('sorts when wrong order of 2 dependencies', () => {
       const roots: RootType[] = [
         {
@@ -571,5 +569,40 @@ describe('anyTypeToTsType', () => {
         'person',
       ]);
     });
+  });
+
+  it('sorts when referencing unknown types', () => {
+    const roots: RootType[] = [
+      {
+        name: 'person',
+        type: {
+          kind: 'record',
+          fields: [
+            {
+              name: 'office',
+              type: { kind: 'named', name: 'office' },
+            },
+          ],
+        },
+      },
+
+      {
+        name: 'office',
+        type: {
+          kind: 'record',
+          fields: [
+            {
+              name: 'address',
+              type: { kind: 'named', name: 'unknownType' },
+            },
+          ],
+        },
+      },
+    ];
+
+    expect(topoSortRoots(roots).map((e) => e.name)).toEqual([
+      'office',
+      'person',
+    ]);
   });
 });

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -313,55 +313,7 @@ describe('getUknownNamedTypes', () => {
 });
 
 describe('topoSortRoots', () => {
-  it('throws with type referencing itself', () => {
-    const roots: RootType[] = [
-      {
-        name: 'person',
-        type: {
-          kind: 'record',
-          fields: [
-            {
-              name: 'parent',
-              type: { kind: 'named', name: 'person' },
-            },
-          ],
-        },
-      },
-    ];
-
-    expect(() => topoSortRoots(roots)).toThrow();
-  });
-
-  it('throws with types referencing each other', () => {
-    const roots: RootType[] = [
-      {
-        name: 'person',
-        type: {
-          kind: 'record',
-          fields: [
-            {
-              name: 'office',
-              type: { kind: 'named', name: 'office' },
-            },
-          ],
-        },
-      },
-      {
-        name: 'office',
-        type: {
-          kind: 'record',
-          fields: [
-            {
-              name: 'owner',
-              type: { kind: 'named', name: 'person' },
-            },
-          ],
-        },
-      },
-    ];
-
-    expect(() => topoSortRoots(roots)).toThrow();
-  });
+  it.todo('test cyclic stuff');
 
   it('sorts when wrong order of 2 dependencies', () => {
     const roots: RootType[] = [

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -179,6 +179,26 @@ describe('circular dependencies detection', () => {
 
     expect(getCyclicDependencies(roots)).toEqual([]);
   });
+
+  it('deals with type referencing unknown types', () => {
+    const roots: RootType[] = [
+      {
+        name: 'person',
+        type: {
+          kind: 'record',
+          fields: [
+            { name: 'id', type: { kind: 'string' } },
+            {
+              name: 'unknown',
+              type: { kind: 'named', name: 'unknownObject ' },
+              nullable: true,
+            },
+          ],
+        },
+      },
+    ];
+    expect(getCyclicDependencies(roots)).toEqual([]);
+  });
 });
 
 describe('getNamedTypes', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,16 +160,15 @@ export function generateRuntypes(
     'import * as rt from "runtypes";\n\n',
   );
 
-  const lazyRoots = Array.from(new Set(cyclicReferences.flat())).map((name) =>
-    roots.find((root) => root.name === name),
-  );
-
-  const terminalRoots = topoSortRoots(
-    roots.filter((e) => !lazyRoots.includes(e)),
-  );
-
-  lazyRoots.forEach((e) => writeLazyRootType(allOptions, writer, e));
-  terminalRoots.forEach((e) => writeTerminalRootType(allOptions, writer, e));
+  const sorted = topoSortRoots(roots);
+  const cyclicRootNames = cyclicReferences.flat();
+  sorted.forEach((root) => {
+    if (cyclicRootNames.includes(root.name)) {
+      writeLazyRootType(allOptions, writer, root);
+    } else {
+      writeTerminalRootType(allOptions, writer, root);
+    }
+  });
 
   const source = writer.getSource();
   return allOptions.format

--- a/src/util.ts
+++ b/src/util.ts
@@ -127,6 +127,10 @@ export function getCyclicDependencies(roots: RootType[]): [string, string][] {
 
   const visitor = (target: string, subject: string, visited: string[]) => {
     const neighbors = nodeEdges[subject];
+    if (neighbors === undefined) {
+      throw new Error(`Neighbors can't be undefined for "${subject}"`);
+    }
+
     visited.push(subject);
     if (neighbors.includes(target)) {
       cycles.push([target, subject]);

--- a/src/util.ts
+++ b/src/util.ts
@@ -128,7 +128,7 @@ export function getCyclicDependencies(roots: RootType[]): [string, string][] {
   const visitor = (target: string, subject: string, visited: string[]) => {
     const neighbors = nodeEdges[subject];
     if (neighbors === undefined) {
-      throw new Error(`Neighbors can't be undefined for "${subject}"`);
+      return;
     }
 
     visited.push(subject);

--- a/src/util.ts
+++ b/src/util.ts
@@ -244,7 +244,7 @@ export function topoSortRoots(roots: readonly RootType[]): RootType[] {
     for (const neighbor of neighbors) {
       const rootToCheck = roots.find((e) => e.name === neighbor);
       if (!rootToCheck) {
-        throw new Error(`Root named "${neighbor}" not found`);
+        continue;
       }
       visitor(rootToCheck, [...visited, root.name]);
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -230,10 +230,9 @@ export function topoSortRoots(roots: readonly RootType[]): RootType[] {
   const checked: RootType[] = [];
 
   function visitor(root: RootType, visited: string[] = []) {
-    if (checked.includes(root)) {
+    // if checked, or cyclic, we're done with the node
+    if (checked.includes(root) || visited.includes(root.name)) {
       return;
-    } else if (visited.includes(root.name)) {
-      throw new Error('Not a DAG: Found cycles in roots.');
     }
 
     const neighbors = getNamedTypes(root.type);


### PR DESCRIPTION
Sort roots topologically by their dependencies before generating code. Makes sure non-lazy types are written in the correct order.

I'll add a couple of more tests, but apart from that, this should be ready. This should land before releasing 3.0