### PR TITLE
feat: Export NameFunction type

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ function makeWriter(): CodeWriter {
   };
 }
 
-type NameFunction = (originalName: string) => string;
+export type NameFunction = (originalName: string) => string;
 
 export interface GenerateOptions {
   /** Apply formatting to the output using prettier. Default: true */


### PR DESCRIPTION
Want to have the type available for libs consuming generate-runtypes