### PR TITLE
fix: Don't throw on names with leading number

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -655,6 +655,33 @@ type Person=rt.Static<typeof person>;"
         "
       `);
     });
+
+    it('handles names that are not valid JS indetifiers', () => {
+      const source = generateRuntypes([
+        {
+          name: '007',
+          type: { kind: 'string' },
+        },
+
+        {
+          name: 'agent',
+          type: { kind: 'named', name: '007' },
+        },
+      ]);
+
+      expect(source).toMatchInlineSnapshot(`
+"import * as rt from \\"runtypes\\";
+
+const _007 = rt.String;
+
+type _007 = rt.Static<typeof _007>;
+
+const agent = _007;
+
+type Agent = rt.Static<typeof agent>;
+"
+`);
+    });
   });
 
   it('generates runtype with `union` kind', () => {

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -6,6 +6,7 @@ import {
   getNamedTypes,
   getUnknownNamedTypes,
   groupFieldKinds,
+  makeValidIdentifier,
   rootToType,
   topoSortRoots,
 } from '../util';
@@ -605,4 +606,10 @@ describe('anyTypeToTsType', () => {
       'person',
     ]);
   });
+});
+
+test('makeValidIdentifier', () => {
+  expect(makeValidIdentifier('asdf')).toEqual('asdf');
+  expect(makeValidIdentifier('1234')).toEqual('_1234');
+  expect(makeValidIdentifier('a1234')).toEqual('a1234');
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import {
   anyTypeToTsType,
   getCyclicDependencies,
   groupFieldKinds,
+  makeValidIdentifier,
   topoSortRoots,
 } from './util';
 
@@ -128,8 +129,9 @@ const defaultOptions: GenerateOptions = {
   format: true,
   includeImport: true,
   includeTypes: true,
-  formatRuntypeName: (e) => e[0].toLowerCase() + e.slice(1),
-  formatTypeName: (e) => e[0].toUpperCase() + e.slice(1),
+  formatRuntypeName: (e) =>
+    makeValidIdentifier(e[0].toLowerCase() + e.slice(1)),
+  formatTypeName: (e) => makeValidIdentifier(e[0].toUpperCase() + e.slice(1)),
   rejectCyclicDependencies: false,
   rejectUnknownNamedTypes: false,
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -255,3 +255,14 @@ export function topoSortRoots(roots: readonly RootType[]): RootType[] {
   roots.forEach((e) => visitor(e));
   return ret.reverse();
 }
+
+const startsWithNumberRegex = /^\d/;
+
+/**
+ * If the name starts with a number, which is not allowed for identifiers in
+ * JavaScript, add a leading underscore to the name and return the new name.
+ * Otherwise, return the input unchanged.
+ */
+export function makeValidIdentifier(name: string): string {
+  return startsWithNumberRegex.test(name) ? `_${name}` : name;
+}


### PR DESCRIPTION
Pads names with a leading underscore, if the name starts with a number, so it becomes a valid JS identifier.

Should fix this downstream: https://github.com/runeh/json-to-runtypes/issues/7